### PR TITLE
Do not create lockfiles while refreshing the index

### DIFF
--- a/mgitstatus
+++ b/mgitstatus
@@ -148,7 +148,7 @@ do
     fi
 
     # Refresh the index, or we might get wrong results.
-    git --work-tree "$(dirname "$GIT_DIR")" --git-dir "$GIT_DIR" update-index -q --refresh >/dev/null 2>&1
+    git --no-optional-locks --work-tree "$(dirname "$GIT_DIR")" --git-dir "$GIT_DIR" update-index -q --refresh >/dev/null 2>&1
 
     # Find all remote branches that have been checked out and figure out if
     # they need a push or pull. We do this with various tests and put the name


### PR DESCRIPTION
The temporary lockfiles where not deleted in some cases. This caused all git repos to be locked when used multi-git-status.